### PR TITLE
update to SPR-8639

### DIFF
--- a/SPR-8639/src/test/java/org/springframework/issues/InterceptorTests.java
+++ b/SPR-8639/src/test/java/org/springframework/issues/InterceptorTests.java
@@ -29,7 +29,8 @@ public class InterceptorTests {
 		c.getD();
 		cWithAutoWired.getD();
 
-		assertEquals( anyInterceptor.getInvokedBy().size(), 1 );
-		assertEquals( anyInterceptor.getInvokedBy().get(0), C.class.getName());
+		assertEquals( anyInterceptor.getInvokedBy().size(), 2 );
+		assertEquals( anyInterceptor.getInvokedBy().get(0), C.class.getName() );
+		assertEquals( anyInterceptor.getInvokedBy().get(1), CWithAutoWired.class.getName() );
 	}
 }


### PR DESCRIPTION
Original test case contained test that was passing, but it shouldn't.
Just changed it to not passing test when it should.
