### PR TITLE
SPR-10704 - mockMvx xpath does not work as expected 

### DIFF
--- a/SPR-10704/pom.xml
+++ b/SPR-10704/pom.xml
@@ -1,0 +1,144 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.springframework.issues</groupId>
+    <artifactId>SPR-10704</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Spring MVC Issue Reproduction Project</name>
+
+    <parent>
+        <groupId>org.springframework.bootstrap</groupId>
+        <artifactId>spring-bootstrap-starters</artifactId>
+        <version>0.5.0.BUILD-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <start-class>org.springframework.site.configuration.ApplicationConfiguration</start-class>
+        <hamcrest.version>1.3</hamcrest.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.bootstrap</groupId>
+            <artifactId>spring-bootstrap-web-starter</artifactId>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-jdk14</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.bootstrap</groupId>
+            <artifactId>spring-bootstrap-actuator-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.rome</groupId>
+            <artifactId>rome</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
+        <!-- Test scope -->
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-integration</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jmock</groupId>
+                    <artifactId>jmock</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.easymock</groupId>
+                    <artifactId>easymock</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*Tests.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>http://repo.springsource.org/snapshot</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>http://repo.springsource.org/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>http://repo.springsource.org/snapshot</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>http://repo.springsource.org/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
+
+</project>
+

--- a/SPR-10704/src/main/java/org/springframework/issues/ApplicationConfiguration.java
+++ b/SPR-10704/src/main/java/org/springframework/issues/ApplicationConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.issues;
+
+import org.springframework.bootstrap.SpringApplication;
+import org.springframework.bootstrap.context.annotation.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@EnableAutoConfiguration
+@Configuration
+@ComponentScan(basePackages = "org.springframework.issues")
+public class ApplicationConfiguration {
+
+	public static void main(String[] args) {
+		new SpringApplication(ApplicationConfiguration.class).run(args);
+	}
+
+	@Bean
+	public BlogPostAtomViewer blogPostAtomViewer(){
+		return new BlogPostAtomViewer();
+	}
+
+}

--- a/SPR-10704/src/main/java/org/springframework/issues/BlogFeedController.java
+++ b/SPR-10704/src/main/java/org/springframework/issues/BlogFeedController.java
@@ -1,0 +1,16 @@
+package org.springframework.issues;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.HEAD;
+
+@Controller
+public class BlogFeedController {
+
+	@RequestMapping(value="/blog.atom", method = { GET, HEAD })
+	public String listPublishedPosts() {
+		return "blogPostAtomViewer";
+	}
+}

--- a/SPR-10704/src/main/java/org/springframework/issues/BlogPostAtomViewer.java
+++ b/SPR-10704/src/main/java/org/springframework/issues/BlogPostAtomViewer.java
@@ -1,0 +1,24 @@
+package org.springframework.issues;
+
+import com.sun.syndication.feed.atom.*;
+import org.springframework.web.servlet.view.feed.AbstractAtomFeedView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.*;
+
+public class BlogPostAtomViewer extends AbstractAtomFeedView {
+
+	@Override
+	protected void buildFeedMetadata(Map<String, Object> model, Feed feed, HttpServletRequest request) {
+		feed.setTitle("Test Feed");
+		feed.setIcon("http://www.example.com/favicon.ico");
+		super.buildFeedMetadata(model, feed, request);
+	}
+
+
+	@Override
+	protected List<Entry> buildFeedEntries(Map<String, Object> stringObjectMap, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception {
+		return null;
+	}
+}

--- a/SPR-10704/src/test/java/org/springframework/issues/BlogAtomFeedsTests.java
+++ b/SPR-10704/src/test/java/org/springframework/issues/BlogAtomFeedsTests.java
@@ -1,0 +1,80 @@
+package org.springframework.issues;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.bootstrap.context.initializer.ConfigFileApplicationContextInitializer;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = ApplicationConfiguration.class, initializers = ConfigFileApplicationContextInitializer.class)
+public class BlogAtomFeedsTests {
+
+	@Autowired
+	private WebApplicationContext wac;
+
+	private MockMvc mockMvc;
+
+	private XPath xpath = XPathFactory.newInstance().newXPath();
+
+	@Before
+	public void setup() {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+	}
+
+	/* This doesn't work !!!! */
+	@Test
+	public void feedHasCorrectMetadataMockMvcXpath() throws Exception {
+		mockMvc.perform(get("/blog.atom"))
+				.andExpect(xpath("/feed/title").string("Test Feed"))
+				.andExpect(xpath("/feed/icon").string("http://www.example.com/favicon.ico"))
+				.andReturn();
+	}
+
+	/* It works this way, but we shouldn't have to do this */
+	@Test
+	public void feedHasCorrectMetadataManualXpath() throws Exception {
+		Document doc = doGetForDocument("/blog.atom");
+
+		assertThat(xpath.evaluate("/feed/title", doc), is("Test Feed"));
+		assertThat(xpath.evaluate("/feed/icon", doc), is("http://www.example.com/favicon.ico"));
+	}
+
+	private Document doGetForDocument(String path) throws Exception {
+		ResultActions resultActions = mockMvc.perform(get(path));
+		MvcResult mvcResult = resultActions.andReturn();
+		return getAtomFeedDocument(mvcResult);
+	}
+
+	private Document getAtomFeedDocument(MvcResult mvcResult) throws ParserConfigurationException, SAXException, IOException {
+		String atomFeed = mvcResult.getResponse().getContentAsString();
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		DocumentBuilder builder = factory.newDocumentBuilder();
+		return builder.parse(new ByteArrayInputStream(atomFeed.getBytes()));
+	}
+}


### PR DESCRIPTION
- Test runs against a simple atom feed constructed using ROME

The original issue - https://jira.springsource.org/browse/SPR-10704 - claimed the problem was with the line endings. Having investigated further, this is not the case. We are not sure why the MockMvc XPath matcher does not work correctly.
