### PR TITLE
reproduce the issue with a unit test.

### DIFF
--- a/SPR-13417/pom.xml
+++ b/SPR-13417/pom.xml
@@ -43,6 +43,12 @@
 			<version>${spring.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<version>${spring.version}</version>
+		</dependency>
+
 		<!-- Logging -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -71,8 +77,8 @@
 		<!-- Servlet API -->
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.0.1</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/SPR-13417/src/main/java/org/springframework/issues/TestController.java
+++ b/SPR-13417/src/main/java/org/springframework/issues/TestController.java
@@ -1,29 +1,36 @@
 package org.springframework.issues;
 
-import org.springframework.stereotype.Controller;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 public class TestController {
 
-    @RequestMapping(name= "/test", method = RequestMethod.POST)
-    @ResponseBody
-    public String handle(@RequestBody(required = false) String body) {
-        return "OK";
-    }
-
-    @RequestMapping(name= "/testjson", method = RequestMethod.POST,
-            produces = "application/json", consumes = "application/json")
-    @ResponseBody
-    public String handle(@RequestBody(required = false) Book body) {
-        return "OK";
+    @RequestMapping(name= "/testjson", method = RequestMethod.POST)
+    @ResponseStatus(HttpStatus.CREATED)
+    public Book handle(@RequestBody(required = false) Book body) {
+        return new Book("Hello", "World");
     }
 
     public class Book {
-        String title;
-        String author;
+        private String title;
+        private String author;
+
+        public Book(String title, String author) {
+            this.title = title;
+            this.author = author;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public String getAuthor() {
+            return author;
+        }
     }
 }

--- a/SPR-13417/src/test/java/org/springframework/issues/TestControllerTest.java
+++ b/SPR-13417/src/test/java/org/springframework/issues/TestControllerTest.java
@@ -1,0 +1,33 @@
+package org.springframework.issues;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+public class TestControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void prepare() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new TestController()).setMessageConverters(new MappingJackson2HttpMessageConverter()).build();
+    }
+
+    @Test
+    public void shouldSend201WhenNoContentTypeAndNoRequestBody() throws Exception {
+        mockMvc.perform(post("/testjson").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated());
+    }
+
+    @Test
+    public void shouldSend201WhenContentTypeSpecifiedAndNoRequestBody() throws Exception {
+        mockMvc.perform(post("/testjson").accept(MediaType.APPLICATION_JSON).contentType(MediaType.APPLICATION_JSON))
+               .andExpect(status().isCreated());
+    }
+}


### PR DESCRIPTION
When sending no content, and thus also no content type, I expect the argument to be set to null, as documented, since the `required` attribute of the `@RequestBody annotation is set to false.

Note that the controller works as expected if a content-type header is set.