### PR TITLE
Polishing cargo.container.uri

### DIFF
--- a/SPR-0000-war-java/pom.xml
+++ b/SPR-0000-war-java/pom.xml
@@ -17,7 +17,7 @@
 		<jetty.version>9.1.2.v20140210</jetty.version>
 		<cargo.container.id>tomcat7x</cargo.container.id>
 		<cargo.container.url>
-			http://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57.zip
+			http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.64/bin/apache-tomcat-7.0.64.zip
 		</cargo.container.url>
 		<cargo.container.jvmargs>-Xms96m -Xmx512m -Djava.awt.headless=true</cargo.container.jvmargs>
 		<cargo.jvm.debug.port>8000</cargo.jvm.debug.port>
@@ -254,7 +254,7 @@
 			<properties>
 				<cargo.container.id>tomcat8x</cargo.container.id>
 				<cargo.container.url>
-          http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.15/bin/apache-tomcat-8.0.15.zip
+					http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip
 				</cargo.container.url>
 			</properties>
 		</profile>

--- a/SPR-0000-war-xml/pom.xml
+++ b/SPR-0000-war-xml/pom.xml
@@ -17,7 +17,7 @@
 		<jetty.version>9.1.2.v20140210</jetty.version>
 		<cargo.container.id>tomcat7x</cargo.container.id>
 		<cargo.container.url>
-			http://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57.zip
+			http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.64/bin/apache-tomcat-7.0.64.zip
 		</cargo.container.url>
 		<cargo.container.jvmargs>-Xms96m -Xmx512m -Djava.awt.headless=true</cargo.container.jvmargs>
 		<cargo.jvm.debug.port>8000</cargo.jvm.debug.port>
@@ -254,7 +254,7 @@
 			<properties>
 				<cargo.container.id>tomcat8x</cargo.container.id>
 				<cargo.container.url>
-					http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.15/bin/apache-tomcat-8.0.15.zip
+					http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip
 				</cargo.container.url>
 			</properties>
 		</profile>


### PR DESCRIPTION
Following configurations are changed.

* The URL of zip installation for tomcat (`www.eu.apache.org` -> `archive.apache.org`)
* Tomcat version (Tomcat7: `7.0.57` -> `7.0.64`, Tomcat8: `8.0.15` -> `8.0.26`)