### PR TITLE
Add sample code for child contexts in test methods

### DIFF
--- a/SPR-12031/pom.xml
+++ b/SPR-12031/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.test</groupId>
+	<artifactId>demo</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>eureka-client</name>
+	<description>Demo project for Spring Boot</description>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>1.8</java.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-config</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-feign</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-eureka</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-ribbon</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-starter-parent</artifactId>
+				<version>Brixton.BUILD-SNAPSHOT</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+	
+	<repositories>
+		<repository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/SPR-12031/src/main/resources/application.properties
+++ b/SPR-12031/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.devtools.remote.secret=dlkfjhd
+eureka.instance.secure-virtual-host-name=${spring.application.name:unknown}
+ribbon.IsSecure=true

--- a/SPR-12031/src/main/resources/bootstrap.properties
+++ b/SPR-12031/src/main/resources/bootstrap.properties
@@ -1,0 +1,5 @@
+# eureka.client.serviceUrl.defaultZone: https://GkW7hXnMKlMS:FV85Yz5pSaUX@eureka-533e6a77-b50a-49a0-a678-426294b0e48d.cfapps.pez.pivotal.io/eureka/
+spring.application.name: eureka-client
+spring.cloud.config.uri: ${vcap.services.configservice.credentials.uri:http://localhost:8888}
+# spring.cloud.config.failFast: true
+logging.level.com.netflix.discovery: OFF

--- a/SPR-12031/src/test/java/demo/ApplicationTests.java
+++ b/SPR-12031/src/test/java/demo/ApplicationTests.java
@@ -1,0 +1,78 @@
+package demo;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+
+import demo.ApplicationTests.Application;
+
+@SpringApplicationConfiguration(classes = Application.class)
+@BootstrapWith(ChildContextBootstrapper.class)
+@IntegrationTest("logging.level.org.springframework.web=DEBUG")
+public class ApplicationTests {
+
+	@ClassRule
+	public static final SpringClassRule springClass = new SpringClassRule();
+
+	@Rule
+	public final ChildMethodRule springMethod = new ChildMethodRule();
+
+	@Autowired
+	private String foo;
+
+	@Test
+	public void contextLoads() {
+		assertEquals("foo", this.foo);
+	}
+
+	@Test
+	@ChildSpringApplication(Child.class)
+	public void contextLoadsChild() {
+		assertEquals("bar", this.foo);
+	}
+
+	@Test
+	@ChildSpringApplication(ChildWithValue.class)
+	@ChildTestProperties("foo=spam")
+	public void contextLoadsChildWithProperties() {
+		assertEquals("spam", this.foo);
+	}
+
+	@Configuration
+	public static class Application {
+		@Bean
+		public String foo() {
+			return "foo";
+		}
+	}
+
+	@Configuration
+	public static class Child {
+		@Bean
+		public String foo() {
+			return "bar";
+		}
+	}
+
+	@Configuration
+	public static class ChildWithValue {
+		@Value("${foo}")
+		private String foo;
+
+		@Bean
+		public String foo() {
+			return this.foo;
+		}
+	}
+
+}

--- a/SPR-12031/src/test/java/demo/ChildContextBootstrapper.java
+++ b/SPR-12031/src/test/java/demo/ChildContextBootstrapper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package demo;
+
+import org.springframework.test.context.ContextLoader;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestContextBootstrapper;
+import org.springframework.test.context.support.DelegatingSmartContextLoader;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class ChildContextBootstrapper extends AbstractTestContextBootstrapper {
+
+	@Override
+	protected Class<? extends ContextLoader> getDefaultContextLoaderClass(
+			Class<?> testClass) {
+		return DelegatingSmartContextLoader.class;
+	}
+
+	@Override
+	public TestContext buildTestContext() {
+		return new ChildTestContext(getBootstrapContext().getTestClass(), buildMergedContextConfiguration(),
+				getCacheAwareContextLoaderDelegate());
+	}
+
+}

--- a/SPR-12031/src/test/java/demo/ChildMethodRule.java
+++ b/SPR-12031/src/test/java/demo/ChildMethodRule.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package demo;
+
+import java.lang.reflect.Method;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestContextManager;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class ChildMethodRule extends SpringMethodRule {
+
+	private static final Log logger = LogFactory.getLog(ChildMethodRule.class);
+
+	@Override
+	public Statement apply(Statement base, FrameworkMethod frameworkMethod, Object testInstance) {
+		Class<?> testClass = testInstance.getClass();
+		Method method = ReflectionUtils.findMethod(SpringClassRule.class, "getTestContextManager", Class.class);
+		ReflectionUtils.makeAccessible(method);
+		TestContextManager testContextManager = (TestContextManager) ReflectionUtils.invokeMethod(method, null, testClass);
+		TestContext testContext = (TestContext) ReflectionTestUtils.getField(testContextManager, "testContext");
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("Applying ChildMethodRule to test method [" + frameworkMethod.getMethod() + "].");
+		}
+		return new Statement() {
+
+			@Override
+			public void evaluate() throws Throwable {
+				delegate(base, frameworkMethod, testInstance, testContext);
+			}
+
+		};
+	}
+
+	public void delegate(Statement base, FrameworkMethod frameworkMethod, Object testInstance, TestContext testContext) throws Throwable {
+		ChildTestContext child = null;
+		if (testContext instanceof ChildTestContext) {
+			child = (ChildTestContext) testContext;
+		}
+		if (child!=null) {
+			child.setTestMethod(frameworkMethod.getMethod());
+		}
+		super.apply(base, frameworkMethod, testInstance).evaluate();
+		if (child!=null) {
+			// Clean up the child context if there is one
+			child.close();
+		}
+	}
+
+}

--- a/SPR-12031/src/test/java/demo/ChildSpringApplication.java
+++ b/SPR-12031/src/test/java/demo/ChildSpringApplication.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package demo;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ChildSpringApplication {
+
+	@AliasFor("classes")
+	Class<?>[] value() default {};
+
+	@AliasFor("value")
+	Class<?>[] classes() default {};
+}

--- a/SPR-12031/src/test/java/demo/ChildTestContext.java
+++ b/SPR-12031/src/test/java/demo/ChildTestContext.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package demo;
+
+import java.lang.reflect.Method;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.Banner.Mode;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.test.context.CacheAwareContextLoaderDelegate;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.test.context.support.DefaultTestContext;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class ChildTestContext extends DefaultTestContext {
+
+	private static final Log logger = LogFactory.getLog(ChildMethodRule.class);
+	private Method method;
+	private ConfigurableApplicationContext closeable;
+
+	public ChildTestContext(Class<?> testClass,
+			MergedContextConfiguration mergedContextConfiguration,
+			CacheAwareContextLoaderDelegate cacheAwareContextLoaderDelegate) {
+		super(testClass, mergedContextConfiguration, cacheAwareContextLoaderDelegate);
+	}
+
+	@Override
+	public ApplicationContext getApplicationContext() {
+		ApplicationContext parent = super.getApplicationContext();
+		ApplicationContext context = parent;
+		if (this.method != null) {
+			SpringApplicationBuilder builder = null;
+			ChildSpringApplication annotation = AnnotatedElementUtils
+					.getMergedAnnotation(this.method, ChildSpringApplication.class);
+			if (annotation != null) {
+				if (annotation.classes().length > 0) {
+					builder = new SpringApplicationBuilder();
+					for (Class<?> source : annotation.classes()) {
+						builder.sources(source);
+					}
+				}
+			}
+			ChildTestProperties properties = AnnotatedElementUtils
+					.getMergedAnnotation(this.method, ChildTestProperties.class);
+			if (properties != null) {
+				if (properties.value().length > 0) {
+					if (builder == null) {
+						builder = new SpringApplicationBuilder();
+					}
+					for (String source : properties.value()) {
+						builder.properties(source);
+					}
+				}
+			}
+			if (builder != null) {
+				this.closeable = builder
+						.sources(PropertyPlaceholderAutoConfiguration.class)
+						.bannerMode(Mode.OFF).web(false)
+						.parent((ConfigurableApplicationContext) parent).run();
+				context = this.closeable;
+			}
+		}
+		return context;
+	}
+
+	public void close() {
+		if (logger.isDebugEnabled()) {
+			logger.debug("Closing child context.");
+		}
+		if (this.closeable != null && this.closeable.isActive()) {
+			this.closeable.close();
+		}
+	}
+
+	public void setTestMethod(Method method) {
+		this.method = method;
+	}
+
+}

--- a/SPR-12031/src/test/java/demo/ChildTestProperties.java
+++ b/SPR-12031/src/test/java/demo/ChildTestProperties.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package demo;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ChildTestProperties {
+
+	String[] value() default {};
+
+}


### PR DESCRIPTION
I blended my original ideas with Thomas's comments and got something
that works with a throwaway context per method if it detects either
@ChildSpringApplication or @ChildTestProperties (separate annotations
needed because the existing analogs at the type level do not
support being added to methods).

There's some reflection hackery to get the TestContext in a MethodRule,
but possibly that would be unnecessary if this feature was supported
in SpringMethodRule.