### PR TITLE
Adjusted tests for SPR-13490

### DIFF
--- a/SPR-13490/src/main/java/org/springframework/issues/TestController.java
+++ b/SPR-13490/src/main/java/org/springframework/issues/TestController.java
@@ -15,8 +15,13 @@ public class TestController {
         binder.addValidators(new PayloadValidator());
     }
 
-    @RequestMapping("/")
-    public String emptyBody(@RequestBody @Validated Payload payload) {
+    @RequestMapping("/mandatory-body")
+    public String mandatoryBody(@RequestBody @Validated Payload payload) {
+        return "hello";
+    }
+
+    @RequestMapping("/optional-body")
+    public String optionalBody(@RequestBody(required = false) @Validated Payload payload) {
         return "hello";
     }
 }

--- a/SPR-13490/src/test/java/org/springframework/issues/TestControllerTest.java
+++ b/SPR-13490/src/test/java/org/springframework/issues/TestControllerTest.java
@@ -24,19 +24,31 @@ public class TestControllerTest {
 
     @Test
     public void shouldSend200WithValidPayload() throws Exception {
-        mockMvc.perform(post("/").content("{\"message\":\"spring\"}").contentType(MediaType.APPLICATION_JSON))
+        mockMvc.perform(post("/mandatory-body").content("{\"message\":\"spring\"}").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().string("\"hello\""));
     }
 
     @Test
     public void shouldSend400WithEmptyBody() throws Exception {
-        mockMvc.perform(post("/")).andExpect(status().isBadRequest());
+        mockMvc.perform(post("/mandatory-body")).andExpect(status().isBadRequest());
     }
 
     @Test
     public void shouldSend400WithEmptyJsonObject() throws Exception {
-        mockMvc.perform(post("/").content("{}").contentType(MediaType.APPLICATION_JSON))
+        mockMvc.perform(post("/mandatory-body").content("{}").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void shouldSend400WithNullJsonObject() throws Exception {
+        mockMvc.perform(post("/mandatory-body").content("null").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void shouldSend200WithNullJsonObject() throws Exception {
+        mockMvc.perform(post("/optional-body").content("null").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
Given the description of the 'required' parameter in RequestBody, the tests for SPR-13490, tests should pass. 

	 * Whether body content is required.
	 * <p>Default is {@code true}, leading to an exception thrown in case
	 * there is no body content. Switch this to {@code false} if you prefer
	 * {@code null} to be passed when the body content is {@code null}.
	 * @since 3.2