### PR TITLE
405 for mistyped URL. Should be 404.

### DIFF
--- a/SPR-13944/pom.xml
+++ b/SPR-13944/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>spring.framework.issues</groupId>
+	<artifactId>SPR.13944</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>SPR-13944</name>
+	<description>405 Method Not Supported for Mistyped URL</description>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>1.3.2.RELEASE</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>1.8</java.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.1</version>
+			<scope>test</scope>
+		</dependency>
+				
+	</dependencies>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+	
+
+</project>

--- a/SPR-13944/src/main/java/spring/framework/issues/_13944/Spr13944Application.java
+++ b/SPR-13944/src/main/java/spring/framework/issues/_13944/Spr13944Application.java
@@ -1,0 +1,36 @@
+package spring.framework.issues._13944;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@SpringBootApplication
+@RestController
+public class Spr13944Application {
+
+    private static Logger log = LoggerFactory.getLogger(Spr13944Application.class);
+    
+	public static void main(String[] args) {
+		SpringApplication.run(Spr13944Application.class, args);
+
+        RestTemplate restTemplate = new RestTemplate();
+        String badUrl = "http://localhost:8080/greetings";
+        for (HttpMethod httpMethod : HttpMethod.values()) {
+            try {
+                restTemplate.execute(badUrl, httpMethod, null, null);
+            } catch (Exception e) {
+                log.error("Failed to " + httpMethod + " -- " + e.getMessage());
+            }
+        }
+    }
+
+    @RequestMapping("/greeting")
+    public String greeting() {
+        return "hello";
+    }
+}

--- a/SPR-13944/src/test/java/spring/framework/issues/_13944/Spr13944ApplicationTests.java
+++ b/SPR-13944/src/test/java/spring/framework/issues/_13944/Spr13944ApplicationTests.java
@@ -1,0 +1,108 @@
+package spring.framework.issues._13944;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.client.ResponseExtractor;
+import org.springframework.web.client.RestTemplate;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = Spr13944Application.class)
+@WebAppConfiguration
+@IntegrationTest
+public class Spr13944ApplicationTests {
+
+	private String goodUrl = "http://localhost:8080/greeting";
+	private String badUrl = "http://localhost:8080/greetings";
+	
+	private RestTemplate restTemplate = new TestRestTemplate();
+	
+	private void requestToCorrectUrlIsOk(HttpMethod httpMethod) {
+		ResponseEntity<String> response = restTemplate.exchange(goodUrl, httpMethod, null, String.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+	
+	private void requestToMistypedUrlIsNotFound(HttpMethod httpMethod) {
+		ResponseEntity<String> response = restTemplate.exchange(badUrl, httpMethod, null, String.class);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+	}
+
+	@Test
+	public void testGetForCorrectUrlIsOk() {
+		requestToCorrectUrlIsOk(HttpMethod.GET);
+	}
+
+	@Test
+	public void testGetForMistypedUrl() { 
+		requestToMistypedUrlIsNotFound(HttpMethod.GET);
+	}
+
+	@Test
+	public void testHeadForCorrectUrlIsOk() { 
+		requestToCorrectUrlIsOk(HttpMethod.HEAD);
+	}
+
+	@Test
+	public void testHeadForMistypedUrl() { 
+		requestToMistypedUrlIsNotFound(HttpMethod.HEAD);
+	}
+
+	@Test
+	public void testPostForCorrectUrlIsOk() {
+		requestToCorrectUrlIsOk(HttpMethod.POST);
+	}
+
+	@Test
+	public void testPostForMistypedUrl() {
+		// This fails with HttpStatus.METHOD_NOT_ALLOWED
+		requestToMistypedUrlIsNotFound(HttpMethod.POST);
+	}
+
+	@Test
+	public void testPutForCorrectUrlIsOk() {
+		requestToCorrectUrlIsOk(HttpMethod.PUT);
+	}
+
+	@Test
+	public void testPutForMistypedUrl() {
+		// This fails with HttpStatus.METHOD_NOT_ALLOWED
+		requestToMistypedUrlIsNotFound(HttpMethod.PUT);
+	}
+
+	@Test
+	public void testDeleteForCorrectUrlIsOk() {
+		requestToCorrectUrlIsOk(HttpMethod.DELETE);
+	}
+
+	@Test
+	public void testDeleteForMistypedUrl() {
+		// This fails with HttpStatus.METHOD_NOT_ALLOWED
+		requestToMistypedUrlIsNotFound(HttpMethod.DELETE);
+	}
+
+	@Test
+	public void testOptionsForCorrectUrlIsOk() {
+		requestToCorrectUrlIsOk(HttpMethod.OPTIONS);
+	}
+
+	@Test
+	public void testOptionsForMistypedUrl() {
+		// This fails with HttpStatus.OK - maybe OK is always the correct status for OPTIONS?
+		requestToMistypedUrlIsNotFound(HttpMethod.OPTIONS);
+	}
+
+}


### PR DESCRIPTION
Spring Boot application and test for Rest Controller. Demonstrates the
http status codes returned for different http methods when the request
URL has a typo.