### PR TITLE
URL Cleanup

### DIFF
--- a/SPR-0000-war-java/pom.xml
+++ b/SPR-0000-war-java/pom.xml
@@ -238,7 +238,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -250,7 +250,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-0000-war-xml/pom.xml
+++ b/SPR-0000-war-xml/pom.xml
@@ -238,7 +238,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -250,7 +250,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-0000/build.gradle
+++ b/SPR-0000/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 
 repositories {
-    maven { url 'http://repo.spring.io/snapshot' }
+    maven { url 'https://repo.spring.io/snapshot' }
     mavenCentral()
 }
 

--- a/SPR-0000/pom.xml
+++ b/SPR-0000/pom.xml
@@ -73,7 +73,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10019/pom.xml
+++ b/SPR-10019/pom.xml
@@ -167,7 +167,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10022/pom.xml
+++ b/SPR-10022/pom.xml
@@ -160,7 +160,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10083/pom.xml
+++ b/SPR-10083/pom.xml
@@ -27,7 +27,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-10095/pom.xml
+++ b/SPR-10095/pom.xml
@@ -176,7 +176,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10125/pom.xml
+++ b/SPR-10125/pom.xml
@@ -27,20 +27,20 @@
 		<!--
 		<repository>
 			<id>s2-release</id>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 		</repository>
 		<repository>
 			<id>s2-milestone</id>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 		<repository>
 			<id>s2-staging</id>
-			<url>http://repo.springsource.org/libs-staging-local</url>
+			<url>https://repo.springsource.org/libs-staging-local</url>
 		</repository>
 		-->
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-10243/pom.xml
+++ b/SPR-10243/pom.xml
@@ -162,7 +162,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10307/pom.xml
+++ b/SPR-10307/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>SPR-10307</name>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/SPR-10309/pom.xml
+++ b/SPR-10309/pom.xml
@@ -34,13 +34,13 @@
 		</dependency>
 	</dependencies>
 	<repositories>
-		<!-- <repository> <id>s2-release</id> <url>http://repo.springsource.org/release</url>
-			</repository> <repository> <id>s2-milestone</id> <url>http://repo.springsource.org/milestone</url>
-			</repository> <repository> <id>s2-staging</id> <url>http://repo.springsource.org/libs-staging-local</url>
+		<!-- <repository> <id>s2-release</id> <url>https://repo.springsource.org/release</url>
+			</repository> <repository> <id>s2-milestone</id> <url>https://repo.springsource.org/milestone</url>
+			</repository> <repository> <id>s2-staging</id> <url>https://repo.springsource.org/libs-staging-local</url>
 			</repository> -->
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10327/pom.xml
+++ b/SPR-10327/pom.xml
@@ -27,20 +27,20 @@
 		<!--
 		<repository>
 			<id>s2-release</id>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 		</repository>
 		<repository>
 			<id>s2-milestone</id>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 		<repository>
 			<id>s2-staging</id>
-			<url>http://repo.springsource.org/libs-staging-local</url>
+			<url>https://repo.springsource.org/libs-staging-local</url>
 		</repository>
 		-->
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-10334/pom.xml
+++ b/SPR-10334/pom.xml
@@ -175,7 +175,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10344/pom.xml
+++ b/SPR-10344/pom.xml
@@ -32,20 +32,20 @@
 		<!--
 		<repository>
 			<id>s2-release</id>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 		</repository>
 		<repository>
 			<id>s2-milestone</id>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 		<repository>
 			<id>s2-staging</id>
-			<url>http://repo.springsource.org/libs-staging-local</url>
+			<url>https://repo.springsource.org/libs-staging-local</url>
 		</repository>
 		-->
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-10374/pom.xml
+++ b/SPR-10374/pom.xml
@@ -163,7 +163,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10440/pom.xml
+++ b/SPR-10440/pom.xml
@@ -450,7 +450,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10485/pom.xml
+++ b/SPR-10485/pom.xml
@@ -86,7 +86,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10549/pom.xml
+++ b/SPR-10549/pom.xml
@@ -27,20 +27,20 @@
 		<!--
 		<repository>
 			<id>s2-release</id>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 		</repository>
 		<repository>
 			<id>s2-milestone</id>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 		<repository>
 			<id>s2-staging</id>
-			<url>http://repo.springsource.org/libs-staging-local</url>
+			<url>https://repo.springsource.org/libs-staging-local</url>
 		</repository>
 		-->
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-10619/pom.xml
+++ b/SPR-10619/pom.xml
@@ -27,21 +27,21 @@
 		<!--
 		<repository>
 			<id>s2-release</id>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 		</repository>
 		-->
 		<repository>
 			<id>s2-milestone</id>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 		<!--
 		<repository>
 			<id>s2-staging</id>
-			<url>http://repo.springsource.org/libs-staging-local</url>
+			<url>https://repo.springsource.org/libs-staging-local</url>
 		</repository>
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 		-->

--- a/SPR-10655/pom.xml
+++ b/SPR-10655/pom.xml
@@ -299,7 +299,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10658/pom.xml
+++ b/SPR-10658/pom.xml
@@ -27,20 +27,20 @@
 		<!--
 		<repository>
 			<id>s2-release</id>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 		</repository>
 		<repository>
 			<id>s2-milestone</id>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 		<repository>
 			<id>s2-staging</id>
-			<url>http://repo.springsource.org/libs-staging-local</url>
+			<url>https://repo.springsource.org/libs-staging-local</url>
 		</repository>
 		-->
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-10697/pom.xml
+++ b/SPR-10697/pom.xml
@@ -169,7 +169,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10704/pom.xml
+++ b/SPR-10704/pom.xml
@@ -106,7 +106,7 @@
         <repository>
             <id>spring-snapshots</id>
             <name>Spring Snapshots</name>
-            <url>http://repo.springsource.org/snapshot</url>
+            <url>https://repo.springsource.org/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -114,7 +114,7 @@
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>
-            <url>http://repo.springsource.org/milestone</url>
+            <url>https://repo.springsource.org/milestone</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -124,7 +124,7 @@
         <pluginRepository>
             <id>spring-snapshots</id>
             <name>Spring Snapshots</name>
-            <url>http://repo.springsource.org/snapshot</url>
+            <url>https://repo.springsource.org/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -132,7 +132,7 @@
         <pluginRepository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>
-            <url>http://repo.springsource.org/milestone</url>
+            <url>https://repo.springsource.org/milestone</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/SPR-10710/pom.xml
+++ b/SPR-10710/pom.xml
@@ -170,7 +170,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10743/pom.xml
+++ b/SPR-10743/pom.xml
@@ -59,20 +59,20 @@
 		<!--
 		<repository>
 			<id>s2-release</id>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 		</repository>
 		<repository>
 			<id>s2-milestone</id>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 		<repository>
 			<id>s2-staging</id>
-			<url>http://repo.springsource.org/libs-staging-local</url>
+			<url>https://repo.springsource.org/libs-staging-local</url>
 		</repository>
 		-->
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-10765/pom.xml
+++ b/SPR-10765/pom.xml
@@ -37,7 +37,7 @@
 	<repositories>
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-10918/pom.xml
+++ b/SPR-10918/pom.xml
@@ -8,7 +8,7 @@
 	<repositories>
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-10934/pom.xml
+++ b/SPR-10934/pom.xml
@@ -76,12 +76,12 @@
 		<repository>
 			<id>spring-maven-release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</repository>
 		<repository>
 			<id>spring-maven-milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 		</repository>
 	</repositories>
 </project>

--- a/SPR-10995/pom.xml
+++ b/SPR-10995/pom.xml
@@ -27,20 +27,20 @@
 		<!--
 		<repository>
 			<id>s2-release</id>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 		</repository>
 		<repository>
 			<id>s2-milestone</id>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 		<repository>
 			<id>s2-staging</id>
-			<url>http://repo.springsource.org/libs-staging-local</url>
+			<url>https://repo.springsource.org/libs-staging-local</url>
 		</repository>
 		-->
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-11016/pom.xml
+++ b/SPR-11016/pom.xml
@@ -175,7 +175,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11022/pom.xml
+++ b/SPR-11022/pom.xml
@@ -27,20 +27,20 @@
 		<!--
 		<repository>
 			<id>s2-release</id>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 		</repository>
 		<repository>
 			<id>s2-milestone</id>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 		<repository>
 			<id>s2-staging</id>
-			<url>http://repo.springsource.org/libs-staging-local</url>
+			<url>https://repo.springsource.org/libs-staging-local</url>
 		</repository>
 		-->
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-11101/pom.xml
+++ b/SPR-11101/pom.xml
@@ -163,7 +163,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11107/pom.xml
+++ b/SPR-11107/pom.xml
@@ -42,7 +42,7 @@
 	<repositories>
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11193/pom.xml
+++ b/SPR-11193/pom.xml
@@ -290,7 +290,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11238/pom.xml
+++ b/SPR-11238/pom.xml
@@ -40,7 +40,7 @@
     <licenses>
         <license>
             <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
     </licenses>
     <developers>
@@ -48,22 +48,22 @@
             <id>yes2000</id>
             <name>Kent Yeh</name>
             <email>kent.yeh????@gmail.com</email>
-            <url>http://code.google.com/p/javawiki/wiki/StarupMaven?wl=zh-Hant</url>
+            <url>https://code.google.com/p/javawiki/wiki/StarupMaven?wl=zh-Hant</url>
             <roles>
                 <role>architect</role>
                 <role>developer</role>
             </roles>
             <timezone>+8</timezone>
             <properties>
-                <picUrl>http://lh3.googleusercontent.com/-riyCbTcpYdo/AAAAAAAAAAI/AAAAAAAAAAA/47MhS2LUlZo/s48-c-k/photo.jpg</picUrl>
+                <picUrl>https://lh3.googleusercontent.com/-riyCbTcpYdo/AAAAAAAAAAI/AAAAAAAAAAA/47MhS2LUlZo/s48-c-k/photo.jpg</picUrl>
             </properties>
         </developer>
     </developers>
     
     <!--Defaine your Srouce Management,設定源碼版本管理-->
     <scm>
-        <url>http://code.google.com/p/test4spring4/source/browse/trunk/</url>
-        <connection>scm:svn:http://test4spring4.googlecode.com/svn/trunk/</connection>
+        <url>https://code.google.com/p/test4spring4/source/browse/trunk/</url>
+        <connection>scm:svn:https://test4spring4.googlecode.com/svn/trunk/</connection>
         <developerConnection>scm:svn:https://test4spring4.googlecode.com/svn/trunk/</developerConnection>
     </scm>
 
@@ -71,7 +71,7 @@
         <repository>
             <id>gwtrepo</id>
             <name>Kent's Repository</name>
-            <url>http://gwtrepo.googlecode.com/svn/repo</url>
+            <url>https://gwtrepo.googlecode.com/svn/repo</url>
         </repository>
     </repositories>
     
@@ -677,14 +677,14 @@
                                 <verbose>false</verbose>
                                 <linksource>true</linksource>
                                 <links>
-                                    <link>http://download.oracle.com/javase/7/docs/api/</link>
-                                    <link>http://download.oracle.com/javaee/7/api/</link>
-                                    <link>http://docs.spring.io/spring/docs/current/javadoc-api/</link>
-                                    <link>http://docs.spring.io/spring-security/site/docs/current/apidocs/</link>
-                                    <link>http://docs.spring.io/spring-mobile/docs/current/api/</link>
-                                    <link>http://docs.jboss.org/hibernate/stable/core/javadocs/</link>
-                                    <link>http://logging.apache.org/log4j/2.x/log4j-api/apidocs/</link>
-                                    <link>http://logging.apache.org/log4j/2.x/log4j-core/apidocs/</link>
+                                    <link>https://download.oracle.com/javase/7/docs/api/</link>
+                                    <link>https://download.oracle.com/javaee/7/api/</link>
+                                    <link>https://docs.spring.io/spring/docs/current/javadoc-api/</link>
+                                    <link>https://docs.spring.io/spring-security/site/docs/current/apidocs/</link>
+                                    <link>https://docs.spring.io/spring-mobile/docs/current/api/</link>
+                                    <link>https://docs.jboss.org/hibernate/stable/core/javadocs/</link>
+                                    <link>https://logging.apache.org/log4j/2.x/log4j-api/apidocs/</link>
+                                    <link>https://logging.apache.org/log4j/2.x/log4j-core/apidocs/</link>
                                 </links>
                             </configuration>
                             <reportSets>

--- a/SPR-11281/pom.xml
+++ b/SPR-11281/pom.xml
@@ -193,7 +193,7 @@
         <repository>
             <id>spring-maven-snapshot</id>
             <name>Springframework Maven Snapshot Repository</name>
-            <url>http://repo.spring.io/snapshot</url>
+            <url>https://repo.spring.io/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/SPR-11322/pom.xml
+++ b/SPR-11322/pom.xml
@@ -22,24 +22,24 @@
         <repository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </repository>
         <repository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </pluginRepository>
         <pluginRepository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </pluginRepository>
     </pluginRepositories>
     <dependencies>

--- a/SPR-11406/pom.xml
+++ b/SPR-11406/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>SPR-11406</artifactId>
     <packaging>war</packaging>
     <version>0.1-wip</version>
-    <url>http://maven.apache.org</url>
+    <url>https://maven.apache.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/SPR-11441/pom.xml
+++ b/SPR-11441/pom.xml
@@ -290,7 +290,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11445/pom.xml
+++ b/SPR-11445/pom.xml
@@ -65,7 +65,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11474/pom.xml
+++ b/SPR-11474/pom.xml
@@ -93,7 +93,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11489/pom.xml
+++ b/SPR-11489/pom.xml
@@ -285,7 +285,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11494/pom.xml
+++ b/SPR-11494/pom.xml
@@ -65,7 +65,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11504/pom.xml
+++ b/SPR-11504/pom.xml
@@ -172,7 +172,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11526/pom.xml
+++ b/SPR-11526/pom.xml
@@ -279,7 +279,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11532/pom.xml
+++ b/SPR-11532/pom.xml
@@ -275,7 +275,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11547/pom.xml
+++ b/SPR-11547/pom.xml
@@ -279,7 +279,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11548/pom.xml
+++ b/SPR-11548/pom.xml
@@ -82,7 +82,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11660/pom.xml
+++ b/SPR-11660/pom.xml
@@ -303,7 +303,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11669/pom.xml
+++ b/SPR-11669/pom.xml
@@ -181,7 +181,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11723/pom.xml
+++ b/SPR-11723/pom.xml
@@ -65,7 +65,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11760/pom.xml
+++ b/SPR-11760/pom.xml
@@ -215,7 +215,7 @@
         <repository>
             <id>spring-maven-snapshot</id>
             <name>Springframework Maven Snapshot Repository</name>
-            <url>http://repo.spring.io/snapshot</url>
+            <url>https://repo.spring.io/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/SPR-11761/pom.xml
+++ b/SPR-11761/pom.xml
@@ -152,7 +152,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11762/pom.xml
+++ b/SPR-11762/pom.xml
@@ -78,7 +78,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11775/pom.xml
+++ b/SPR-11775/pom.xml
@@ -90,7 +90,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11844/pom.xml
+++ b/SPR-11844/pom.xml
@@ -38,7 +38,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11915/pom.xml
+++ b/SPR-11915/pom.xml
@@ -92,7 +92,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-11948/pom.xml
+++ b/SPR-11948/pom.xml
@@ -17,7 +17,7 @@
 		<jetty.version>9.1.2.v20140210</jetty.version>
 		<cargo.container.id>tomcat6x</cargo.container.id>
 		<cargo.container.url>
-			http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.35/bin/apache-tomcat-6.0.35.zip
+			https://archive.apache.org/dist/tomcat/tomcat-6/v6.0.35/bin/apache-tomcat-6.0.35.zip
 		</cargo.container.url>
 		<cargo.container.jvmargs>-Xms96m -Xmx512m -Djava.awt.headless=true</cargo.container.jvmargs>
 		<cargo.jvm.debug.port>8000</cargo.jvm.debug.port>
@@ -299,7 +299,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12013/pom.xml
+++ b/SPR-12013/pom.xml
@@ -117,7 +117,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12033/pom.xml
+++ b/SPR-12033/pom.xml
@@ -286,7 +286,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12132/pom.xml
+++ b/SPR-12132/pom.xml
@@ -285,7 +285,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12162/pom.xml
+++ b/SPR-12162/pom.xml
@@ -286,7 +286,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12165/pom.xml
+++ b/SPR-12165/pom.xml
@@ -62,14 +62,14 @@
 				<enabled>false</enabled>
 			</snapshots>
 			<id>spring-milestones</id>
-			<url>http://repo.spring.io/libs-milestone/</url>
+			<url>https://repo.spring.io/libs-milestone/</url>
 		</repository>
 		<repository>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
 			<id>spring-snapshots</id>
-			<url>http://repo.spring.io/libs-snapshot/</url>
+			<url>https://repo.spring.io/libs-snapshot/</url>
 		</repository>
 	</repositories>
 </project>

--- a/SPR-12229/pom.xml
+++ b/SPR-12229/pom.xml
@@ -290,7 +290,7 @@
         <repository>
             <id>spring-maven-snapshot</id>
             <name>Springframework Maven Snapshot Repository</name>
-            <url>http://repo.spring.io/snapshot</url>
+            <url>https://repo.spring.io/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/SPR-12287/pom.xml
+++ b/SPR-12287/pom.xml
@@ -284,7 +284,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12332/pom.xml
+++ b/SPR-12332/pom.xml
@@ -297,7 +297,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12361/pom.xml
+++ b/SPR-12361/pom.xml
@@ -290,7 +290,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12372/pom.xml
+++ b/SPR-12372/pom.xml
@@ -279,7 +279,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12432/pom.xml
+++ b/SPR-12432/pom.xml
@@ -227,7 +227,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12438/pom.xml
+++ b/SPR-12438/pom.xml
@@ -307,7 +307,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12459/pom.xml
+++ b/SPR-12459/pom.xml
@@ -306,7 +306,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12472/pom.xml
+++ b/SPR-12472/pom.xml
@@ -338,7 +338,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12481/pom.xml
+++ b/SPR-12481/pom.xml
@@ -310,7 +310,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12531/pom.xml
+++ b/SPR-12531/pom.xml
@@ -297,7 +297,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12550/pom.xml
+++ b/SPR-12550/pom.xml
@@ -305,7 +305,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12558/pom.xml
+++ b/SPR-12558/pom.xml
@@ -104,7 +104,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12569/pom.xml
+++ b/SPR-12569/pom.xml
@@ -299,7 +299,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12640/pom.xml
+++ b/SPR-12640/pom.xml
@@ -296,7 +296,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12668/pom.xml
+++ b/SPR-12668/pom.xml
@@ -299,7 +299,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12669/pom.xml
+++ b/SPR-12669/pom.xml
@@ -297,7 +297,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12670/pom.xml
+++ b/SPR-12670/pom.xml
@@ -292,7 +292,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12695/pom.xml
+++ b/SPR-12695/pom.xml
@@ -256,7 +256,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12712/pom.xml
+++ b/SPR-12712/pom.xml
@@ -313,7 +313,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12747/pom.xml
+++ b/SPR-12747/pom.xml
@@ -305,7 +305,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12848/pom.xml
+++ b/SPR-12848/pom.xml
@@ -292,7 +292,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12852/pom.xml
+++ b/SPR-12852/pom.xml
@@ -305,7 +305,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-12999/pom.xml
+++ b/SPR-12999/pom.xml
@@ -241,7 +241,7 @@
 						<!-- <containerId>jetty9x</containerId> -->
 						<containerId>tomcat6x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.44/bin/apache-tomcat-6.0.44.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-6/v6.0.44/bin/apache-tomcat-6.0.44.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -267,7 +267,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13050/pom.xml
+++ b/SPR-13050/pom.xml
@@ -75,7 +75,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13078/pom.xml
+++ b/SPR-13078/pom.xml
@@ -214,7 +214,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13102/pom.xml
+++ b/SPR-13102/pom.xml
@@ -79,7 +79,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13124/pom.xml
+++ b/SPR-13124/pom.xml
@@ -95,7 +95,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13197/pom.xml
+++ b/SPR-13197/pom.xml
@@ -292,7 +292,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13329/pom.xml
+++ b/SPR-13329/pom.xml
@@ -83,7 +83,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13359/pom.xml
+++ b/SPR-13359/pom.xml
@@ -85,7 +85,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13367/pom.xml
+++ b/SPR-13367/pom.xml
@@ -324,7 +324,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13375/pom.xml
+++ b/SPR-13375/pom.xml
@@ -143,7 +143,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13379/pom.xml
+++ b/SPR-13379/pom.xml
@@ -219,7 +219,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13412/pom.xml
+++ b/SPR-13412/pom.xml
@@ -292,7 +292,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13417/pom.xml
+++ b/SPR-13417/pom.xml
@@ -296,7 +296,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13418/pom.xml
+++ b/SPR-13418/pom.xml
@@ -297,7 +297,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13490/pom.xml
+++ b/SPR-13490/pom.xml
@@ -295,7 +295,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13498/pom.xml
+++ b/SPR-13498/pom.xml
@@ -294,7 +294,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13502/pom.xml
+++ b/SPR-13502/pom.xml
@@ -17,7 +17,7 @@
 		<jetty.version>9.1.2.v20140210</jetty.version>
 		<cargo.container.id>tomcat7x</cargo.container.id>
 		<cargo.container.url>
-			http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.64/bin/apache-tomcat-7.0.64.zip
+			https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.64/bin/apache-tomcat-7.0.64.zip
 		</cargo.container.url>
 		<cargo.container.jvmargs>-Xms96m -Xmx512m -Djava.awt.headless=true</cargo.container.jvmargs>
 		<cargo.jvm.debug.port>8000</cargo.jvm.debug.port>
@@ -259,7 +259,7 @@
 			<properties>
 				<cargo.container.id>tomcat8x</cargo.container.id>
 				<cargo.container.url>
-					http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip
+					https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip
 				</cargo.container.url>
 			</properties>
 		</profile>
@@ -297,7 +297,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13503/pom.xml
+++ b/SPR-13503/pom.xml
@@ -295,7 +295,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13516/pom.xml
+++ b/SPR-13516/pom.xml
@@ -17,7 +17,7 @@
 		<jetty.version>9.1.2.v20140210</jetty.version>
 		<cargo.container.id>tomcat7x</cargo.container.id>
 		<cargo.container.url>
-			http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.64/bin/apache-tomcat-7.0.64.zip
+			https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.64/bin/apache-tomcat-7.0.64.zip
 		</cargo.container.url>
 		<cargo.container.jvmargs>-Xms96m -Xmx512m -Djava.awt.headless=true</cargo.container.jvmargs>
 		<cargo.jvm.debug.port>8000</cargo.jvm.debug.port>
@@ -252,7 +252,7 @@
 			<properties>
 				<cargo.container.id>tomcat8x</cargo.container.id>
 				<cargo.container.url>
-					http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.15/bin/apache-tomcat-8.0.15.zip
+					https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.15/bin/apache-tomcat-8.0.15.zip
 				</cargo.container.url>
 			</properties>
 		</profile>
@@ -290,7 +290,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13565/pom.xml
+++ b/SPR-13565/pom.xml
@@ -238,7 +238,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -250,7 +250,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13580/mvnw
+++ b/SPR-13580/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/SPR-13580/mvnw.cmd
+++ b/SPR-13580/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/SPR-13615/pom.xml
+++ b/SPR-13615/pom.xml
@@ -96,7 +96,7 @@
         <repository>
             <id>spring-maven-snapshot</id>
             <name>Springframework Maven Snapshot Repository</name>
-            <url>http://repo.spring.io/snapshot</url>
+            <url>https://repo.spring.io/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/SPR-13639/pom.xml
+++ b/SPR-13639/pom.xml
@@ -242,7 +242,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -254,7 +254,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13733/pom.xml
+++ b/SPR-13733/pom.xml
@@ -79,7 +79,7 @@
         <repository>
             <id>spring-maven-snapshot</id>
             <name>Springframework Maven Snapshot Repository</name>
-            <url>http://repo.spring.io/snapshot</url>
+            <url>https://repo.spring.io/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/SPR-13742/pom.xml
+++ b/SPR-13742/pom.xml
@@ -247,7 +247,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -259,7 +259,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13757/pom.xml
+++ b/SPR-13757/pom.xml
@@ -235,7 +235,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -247,7 +247,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13769/pom.xml
+++ b/SPR-13769/pom.xml
@@ -102,7 +102,7 @@
         <repository>
             <id>spring-maven-snapshot</id>
             <name>Springframework Maven Snapshot Repository</name>
-            <url>http://repo.spring.io/snapshot</url>
+            <url>https://repo.spring.io/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/SPR-13770/pom.xml
+++ b/SPR-13770/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>SPR-13770</name>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -98,7 +98,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13806/pom.xml
+++ b/SPR-13806/pom.xml
@@ -243,7 +243,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -255,7 +255,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13872/pom.xml
+++ b/SPR-13872/pom.xml
@@ -250,7 +250,7 @@
 					<container>
 						<containerId>tomcat7x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.67/bin/apache-tomcat-7.0.67.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.67/bin/apache-tomcat-7.0.67.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -262,7 +262,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13876/pom.xml
+++ b/SPR-13876/pom.xml
@@ -86,7 +86,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13946/pom.xml
+++ b/SPR-13946/pom.xml
@@ -237,7 +237,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -249,7 +249,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-13978/pom.xml
+++ b/SPR-13978/pom.xml
@@ -167,7 +167,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -187,7 +187,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-14021/mvnw
+++ b/SPR-14021/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/SPR-14021/mvnw.cmd
+++ b/SPR-14021/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/SPR-14030/mvnw
+++ b/SPR-14030/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/SPR-14030/mvnw.cmd
+++ b/SPR-14030/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/SPR-14038/pom.xml
+++ b/SPR-14038/pom.xml
@@ -122,7 +122,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-14061/pom.xml
+++ b/SPR-14061/pom.xml
@@ -73,7 +73,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-14096/pom.xml
+++ b/SPR-14096/pom.xml
@@ -249,7 +249,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.32/bin/apache-tomcat-8.0.32.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.32/bin/apache-tomcat-8.0.32.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -261,7 +261,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-14291/pom.xml
+++ b/SPR-14291/pom.xml
@@ -237,7 +237,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.32/bin/apache-tomcat-8.0.32.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.32/bin/apache-tomcat-8.0.32.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -249,7 +249,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-14305/pom.xml
+++ b/SPR-14305/pom.xml
@@ -242,7 +242,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -254,7 +254,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-14326/pom.xml
+++ b/SPR-14326/pom.xml
@@ -236,7 +236,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -248,7 +248,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -256,7 +256,7 @@
 		<repository>
 			<id>spring-maven-milestone</id>
 			<name>Springframework Maven Milestone Repository</name>
-			<url>http://repo.spring.io/milestone</url>
+			<url>https://repo.spring.io/milestone</url>
 		</repository>
 	</repositories>
 

--- a/SPR-14368/pom.xml
+++ b/SPR-14368/pom.xml
@@ -237,7 +237,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -249,7 +249,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-14383/pom.xml
+++ b/SPR-14383/pom.xml
@@ -237,7 +237,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -249,7 +249,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-14397/pom.xml
+++ b/SPR-14397/pom.xml
@@ -75,7 +75,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -93,7 +93,7 @@
         <pluginRepository>
         	<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-14444/pom.xml
+++ b/SPR-14444/pom.xml
@@ -56,7 +56,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>

--- a/SPR-14558/pom.xml
+++ b/SPR-14558/pom.xml
@@ -248,7 +248,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -260,7 +260,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-14596/pom.xml
+++ b/SPR-14596/pom.xml
@@ -247,7 +247,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -259,7 +259,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-14619/pom.xml
+++ b/SPR-14619/pom.xml
@@ -235,7 +235,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -247,7 +247,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-14702/mvnw
+++ b/SPR-14702/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/SPR-14702/mvnw.cmd
+++ b/SPR-14702/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/SPR-14719/mvnw
+++ b/SPR-14719/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/SPR-14719/mvnw.cmd
+++ b/SPR-14719/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/SPR-14733/pom.xml
+++ b/SPR-14733/pom.xml
@@ -238,7 +238,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -250,7 +250,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-14739/mvnw
+++ b/SPR-14739/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/SPR-14739/mvnw.cmd
+++ b/SPR-14739/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/SPR-15055/build.gradle
+++ b/SPR-15055/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'org.springframework.boot'
 apply plugin: 'idea'
 
 repositories {
-    maven { url 'http://repo.spring.io/snapshot' }
+    maven { url 'https://repo.spring.io/snapshot' }
     mavenCentral()
 }
 

--- a/SPR-15325/pom.xml
+++ b/SPR-15325/pom.xml
@@ -247,7 +247,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -259,7 +259,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-15337/pom.xml
+++ b/SPR-15337/pom.xml
@@ -238,7 +238,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>

--- a/SPR-15384/pom.xml
+++ b/SPR-15384/pom.xml
@@ -73,7 +73,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-15651/pom.xml
+++ b/SPR-15651/pom.xml
@@ -115,7 +115,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/libs-snapshot</url>
+			<url>https://repo.spring.io/libs-snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-15672/pom.xml
+++ b/SPR-15672/pom.xml
@@ -83,7 +83,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-15701/build.gradle
+++ b/SPR-15701/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     repositories {
         maven {
-            url "http://repo.spring.io/libs-milestone"
+            url "https://repo.spring.io/libs-milestone"
         }
         mavenCentral()
     }
@@ -18,7 +18,7 @@ buildscript {
 
 repositories {
     maven {
-        url "http://repo.spring.io/libs-milestone"
+        url "https://repo.spring.io/libs-milestone"
     }
     mavenCentral()
 }

--- a/SPR-15707/pom.xml
+++ b/SPR-15707/pom.xml
@@ -72,7 +72,7 @@
 		<repository>
 			<id>spring-maven-milestone</id>
 			<name>Springframework Maven Milestone Repository</name>
-			<url>http://repo.spring.io/milestone</url>
+			<url>https://repo.spring.io/milestone</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-15790/mvnw
+++ b/SPR-15790/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/SPR-15790/mvnw.cmd
+++ b/SPR-15790/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/SPR-15794/mvnw
+++ b/SPR-15794/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/SPR-15794/mvnw.cmd
+++ b/SPR-15794/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/SPR-15842/pom.xml
+++ b/SPR-15842/pom.xml
@@ -237,7 +237,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -249,7 +249,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-16350/mvnw
+++ b/SPR-16350/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/SPR-16350/mvnw.cmd
+++ b/SPR-16350/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/SPR-16506/pom.xml
+++ b/SPR-16506/pom.xml
@@ -238,7 +238,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -250,7 +250,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-16846/mvnw
+++ b/SPR-16846/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/SPR-16846/mvnw.cmd
+++ b/SPR-16846/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/SPR-16879/mvnw
+++ b/SPR-16879/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/SPR-16879/mvnw.cmd
+++ b/SPR-16879/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/SPR-17239/mvnw
+++ b/SPR-17239/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/SPR-17239/mvnw.cmd
+++ b/SPR-17239/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/SPR-17521-2/pom.xml
+++ b/SPR-17521-2/pom.xml
@@ -178,7 +178,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-17521/pom.xml
+++ b/SPR-17521/pom.xml
@@ -238,7 +238,7 @@
 					<container>
 						<containerId>tomcat8x</containerId>
 						<zipUrlInstaller>
-							<url>http://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
+							<url>https://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</url>
 						</zipUrlInstaller>
 					</container>
 				</configuration>
@@ -250,7 +250,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-5292/pom.xml
+++ b/SPR-5292/pom.xml
@@ -32,7 +32,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-5628/build.gradle
+++ b/SPR-5628/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'idea'
 repositories {
     mavenLocal()
     mavenCentral()
-    mavenRepo urls: 'http://maven.springframework.org/snapshot'
+    mavenRepo urls: 'https://maven.springframework.org/snapshot'
 }
 
 dependencies {

--- a/SPR-5628/pom.xml
+++ b/SPR-5628/pom.xml
@@ -114,7 +114,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -132,7 +132,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/SPR-6508/pom.xml
+++ b/SPR-6508/pom.xml
@@ -27,7 +27,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-6564/pom.xml
+++ b/SPR-6564/pom.xml
@@ -27,23 +27,23 @@
 		<!--
 		<repository>
 			<id>s2-release</id>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 		</repository>
 		<repository>
 			<id>s2-release</id>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 		</repository>
 		<repository>
 			<id>s2-milestone</id>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 		<repository>
 			<id>s2-staging</id>
-			<url>http://repo.springsource.org/libs-staging-local</url>
+			<url>https://repo.springsource.org/libs-staging-local</url>
 		</repository>
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	-->

--- a/SPR-7093/pom.xml
+++ b/SPR-7093/pom.xml
@@ -257,7 +257,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-7345/pom.xml
+++ b/SPR-7345/pom.xml
@@ -163,7 +163,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-7900/pom.xml
+++ b/SPR-7900/pom.xml
@@ -35,7 +35,7 @@
     <repository>
         <id>spring-maven-snapshot</id>
         <name>Springframework Maven SNAPSHOT Repository</name>
-        <url>http://maven.springframework.org/snapshot</url>
+        <url>https://maven.springframework.org/snapshot</url>
         <snapshots><enabled>true</enabled></snapshots>
     </repository> 
     </repositories>

--- a/SPR-7913/pom.xml
+++ b/SPR-7913/pom.xml
@@ -308,7 +308,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-7943/pom.xml
+++ b/SPR-7943/pom.xml
@@ -170,7 +170,7 @@
 		<repository>
 			<id>org.springframework.maven.snapshot</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
@@ -178,7 +178,7 @@
 		<repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 		<!-- For Spring Roo artifacts -->
@@ -198,7 +198,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<snapshots><enabled>false</enabled></snapshots>			
 		</repository>		
 	</repositories>

--- a/SPR-7963/pom.xml
+++ b/SPR-7963/pom.xml
@@ -163,7 +163,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-7985/pom.xml
+++ b/SPR-7985/pom.xml
@@ -42,7 +42,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-8016/pom.xml
+++ b/SPR-8016/pom.xml
@@ -297,7 +297,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-8122/pom.xml
+++ b/SPR-8122/pom.xml
@@ -27,7 +27,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-8473/pom.xml
+++ b/SPR-8473/pom.xml
@@ -163,7 +163,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-8482/pom.xml
+++ b/SPR-8482/pom.xml
@@ -38,7 +38,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-8491/pom.xml
+++ b/SPR-8491/pom.xml
@@ -9,7 +9,7 @@
 	<repositories>
 		<repository>
 			<id>springsource</id>
-			<url>http://repo.springsource.org/libs-snapshot</url>
+			<url>https://repo.springsource.org/libs-snapshot</url>
 		</repository>
 	</repositories>
 	<dependencies>

--- a/SPR-8492/build.gradle
+++ b/SPR-8492/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'idea'
 repositories {
     mavenLocal()
     mavenCentral()
-    mavenRepo urls: 'http://maven.springframework.org/snapshot'
+    mavenRepo urls: 'https://maven.springframework.org/snapshot'
 }
 
 dependencies {

--- a/SPR-8492/pom.xml
+++ b/SPR-8492/pom.xml
@@ -80,7 +80,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-8499/pom.xml
+++ b/SPR-8499/pom.xml
@@ -51,7 +51,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-8502/pom.xml
+++ b/SPR-8502/pom.xml
@@ -44,7 +44,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-8515/build.gradle
+++ b/SPR-8515/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'idea'
 repositories {
     mavenLocal()
     mavenCentral()
-    mavenRepo urls: 'http://maven.springframework.org/snapshot'
+    mavenRepo urls: 'https://maven.springframework.org/snapshot'
 }
 
 dependencies {

--- a/SPR-8515/pom.xml
+++ b/SPR-8515/pom.xml
@@ -100,7 +100,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -118,7 +118,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/SPR-8522/pom.xml
+++ b/SPR-8522/pom.xml
@@ -16,7 +16,7 @@
     <repositories>
         <repository>
             <id>SpringSource Repository</id>
-            <url>http://maven.springframework.org/snapshot</url>
+            <url>https://maven.springframework.org/snapshot</url>
         </repository>
     </repositories>
     <dependencies>

--- a/SPR-8523/pom.xml
+++ b/SPR-8523/pom.xml
@@ -54,13 +54,13 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 		<repository>
 			<id>maven-central</id>
 			<name>Maven Central Repository</name>
-			<url>http://repo1.maven.org/maven2/</url>
+			<url>https://repo1.maven.org/maven2/</url>
 		</repository>
 	</repositories>
 	<properties>

--- a/SPR-8536/pom.xml
+++ b/SPR-8536/pom.xml
@@ -100,7 +100,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -118,7 +118,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/SPR-8625/pom.xml
+++ b/SPR-8625/pom.xml
@@ -78,7 +78,7 @@
         <repository>
             <id>openehealth.releases</id>
             <name>Open eHealth Maven Repository</name>
-            <url>http://repo.openehealth.org/maven2/releases</url>
+            <url>https://repo.openehealth.org/maven2/releases</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -89,7 +89,7 @@
         <repository>
             <id>openehealth.snapshots</id>
             <name>Open eHealth Maven Repository</name>
-            <url>http://repo.openehealth.org/maven2/snapshots</url>
+            <url>https://repo.openehealth.org/maven2/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -100,12 +100,12 @@
         <repository>
             <id>java.net</id>
             <name>java.net Maven Repository</name>
-            <url>http://download.java.net/maven/2/</url>
+            <url>https://download.java.net/maven/2/</url>
         </repository>
         <repository>
             <id>codehaus</id>
             <name>Codehaus Maven Repository</name>
-            <url>http://repository.codehaus.org</url>
+            <url>https://repository.codehaus.org</url>
         </repository>
         <repository>
             <id>hapi-sf</id>

--- a/SPR-8639/pom.xml
+++ b/SPR-8639/pom.xml
@@ -33,7 +33,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-8651/pom.xml
+++ b/SPR-8651/pom.xml
@@ -44,7 +44,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-8658/pom.xml
+++ b/SPR-8658/pom.xml
@@ -111,7 +111,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -129,7 +129,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/SPR-8661/pom.xml
+++ b/SPR-8661/pom.xml
@@ -104,7 +104,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -122,7 +122,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/SPR-8663/pom.xml
+++ b/SPR-8663/pom.xml
@@ -37,7 +37,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-8683/pom.xml
+++ b/SPR-8683/pom.xml
@@ -27,7 +27,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-8711/pom.xml
+++ b/SPR-8711/pom.xml
@@ -123,7 +123,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -141,7 +141,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/SPR-8714/pom.xml
+++ b/SPR-8714/pom.xml
@@ -27,7 +27,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-8725/pom.xml
+++ b/SPR-8725/pom.xml
@@ -114,7 +114,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -132,7 +132,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/SPR-8726/pom.xml
+++ b/SPR-8726/pom.xml
@@ -10,7 +10,7 @@
 		<repository>
 			<id>org.springframework.maven.snapshot</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>
@@ -22,7 +22,7 @@
 		<repository>
 			<id>org.springframework.maven.milestone</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/SPR-8736/pom.xml
+++ b/SPR-8736/pom.xml
@@ -163,7 +163,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-8743/build.gradle
+++ b/SPR-8743/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'idea'
 repositories {
     mavenLocal()
     mavenCentral()
-    mavenRepo urls: 'http://maven.springframework.org/snapshot'
+    mavenRepo urls: 'https://maven.springframework.org/snapshot'
 }
 
 dependencies {

--- a/SPR-8743/pom.xml
+++ b/SPR-8743/pom.xml
@@ -135,7 +135,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -153,7 +153,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -162,7 +162,7 @@
 		<repository>
 			<id>prime-repo</id>
 			<name>Prime Technology Maven Repository</name>
-			<url>http://repository.primefaces.org</url>
+			<url>https://repository.primefaces.org</url>
 			<layout>default</layout>
 		</repository>
 	</repositories>

--- a/SPR-8761/pom.xml
+++ b/SPR-8761/pom.xml
@@ -31,7 +31,7 @@
 		<repository>
 			<id>springsource</id>
 			<name>springsource</name>
-			<url>http://repo.springsource.org/libs-snapshot</url>
+			<url>https://repo.springsource.org/libs-snapshot</url>
 		</repository>
 	</repositories>
 </project>

--- a/SPR-8769/pom.xml
+++ b/SPR-8769/pom.xml
@@ -69,7 +69,7 @@
     <!-- <repository> -->
     <!-- <id>spring-maven-snapshot</id> -->
     <!-- <name>Springframework Maven Snapshot Repository</name> -->
-    <!-- <url>http://maven.springframework.org/snapshot</url> -->
+    <!-- <url>https://maven.springframework.org/snapshot</url> -->
     <!-- <snapshots><enabled>true</enabled></snapshots> -->
     <!-- </repository> -->
     <!-- </repositories> -->

--- a/SPR-8813/pom.xml
+++ b/SPR-8813/pom.xml
@@ -42,7 +42,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-8824/pom.xml
+++ b/SPR-8824/pom.xml
@@ -22,7 +22,7 @@
     <repository>
       <id>spring-maven-release</id>
       <name>Spring Maven Release Repository</name>
-      <url>http://maven.springframework.org/release</url>
+      <url>https://maven.springframework.org/release</url>
     </repository>
     <repository>
       <id>spring-maven-snapshot</id>
@@ -30,17 +30,17 @@
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
-      <url>http://maven.springframework.org/snapshot</url>
+      <url>https://maven.springframework.org/snapshot</url>
     </repository>
     <repository>
       <id>spring-maven-milestone</id>
       <name>Spring Maven Milestone Repository</name>
-      <url>http://maven.springframework.org/milestone</url>
+      <url>https://maven.springframework.org/milestone</url>
     </repository>
     <repository>
       <id>neo4j-release-repository</id>
       <name>Neo4j Maven 2 release repository</name>
-      <url>http://m2.neo4j.org/releases</url>
+      <url>https://m2.neo4j.org/releases</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -51,7 +51,7 @@
     <repository>
       <id>neo4j-snapshot-repository</id>
       <name>Neo4j Maven 2 snapshot repository</name>
-      <url>http://m2.neo4j.org/snapshots</url>
+      <url>https://m2.neo4j.org/snapshots</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
@@ -65,12 +65,12 @@
     <pluginRepository>
       <id>spring-maven-release</id>
       <name>Spring Maven Release Repository</name>
-      <url>http://maven.springframework.org/release</url>
+      <url>https://maven.springframework.org/release</url>
     </pluginRepository>
     <pluginRepository>
       <id>spring-maven-milestone</id>
       <name>Spring Maven Milestone Repository</name>
-      <url>http://maven.springframework.org/milestone</url>
+      <url>https://maven.springframework.org/milestone</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/SPR-8825/pom.xml
+++ b/SPR-8825/pom.xml
@@ -164,7 +164,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-8853/pom.xml
+++ b/SPR-8853/pom.xml
@@ -86,12 +86,12 @@
         <!-- </snapshots> -->
         <!-- <id>repo1.maven.org</id> -->
         <!-- <name>Maven Central Repository</name> -->
-        <!-- <url>http://repo1.maven.org/maven2</url> -->
+        <!-- <url>https://repo1.maven.org/maven2</url> -->
         <!-- </repository> -->
         <repository>
             <id>spring-maven-snapshot</id>
             <name>Springframework Maven Snapshot Repository</name>
-            <url>http://maven.springframework.org/snapshot</url>
+            <url>https://maven.springframework.org/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -99,7 +99,7 @@
         <repository>
             <id>spring-milestone</id>
             <name>Spring Portfolio Milestone Repository</name>
-            <url>http://s3.amazonaws.com/maven.springframework.org/milestone</url>
+            <url>https://s3.amazonaws.com/maven.springframework.org/milestone</url>
         </repository>
     </repositories>
     <build>

--- a/SPR-8867/pom.xml
+++ b/SPR-8867/pom.xml
@@ -101,7 +101,7 @@
     <repository>
       <id>spring-maven-snapshot</id>
       <name>Springframework Maven Snapshot Repository</name>
-      <url>http://maven.springframework.org/snapshot</url>
+      <url>https://maven.springframework.org/snapshot</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
@@ -119,7 +119,7 @@
     <repository>
       <id>maven2-repository.dev.java.net</id>
       <name>Java.net Repository for Maven</name>
-      <url>http://download.java.net/maven/2/</url>
+      <url>https://download.java.net/maven/2/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/SPR-8905/pom.xml
+++ b/SPR-8905/pom.xml
@@ -37,7 +37,7 @@
 	<repositories>
 		<repository>
 			<id>spring.milestones</id>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 	</repositories>
 </project>

--- a/SPR-8923/pom.xml
+++ b/SPR-8923/pom.xml
@@ -8,7 +8,7 @@
 	<version>1.0.0.CI-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>Spring Utility</name>
-	<url>http://www.springframework.org</url>
+	<url>https://www.springframework.org</url>
 	<description>
 		<![CDATA[
       This project is a minimal jar utility with Spring configuration.

--- a/SPR-8937/pom.xml
+++ b/SPR-8937/pom.xml
@@ -8,7 +8,7 @@
 	<version>0.0.1.SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>Spring JIRA Bug Reproduce</name>
-	<url>http://www.springframework.org</url>
+	<url>https://www.springframework.org</url>
 	<properties>
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>
 		<!-- <spring.framework.version>3.0.7.RELEASE</spring.framework.version> -->

--- a/SPR-8947/pom.xml
+++ b/SPR-8947/pom.xml
@@ -163,7 +163,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-8955/pom.xml
+++ b/SPR-8955/pom.xml
@@ -27,7 +27,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-8991/pom.xml
+++ b/SPR-8991/pom.xml
@@ -99,7 +99,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -117,7 +117,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/SPR-9035/pom.xml
+++ b/SPR-9035/pom.xml
@@ -100,7 +100,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -118,7 +118,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/SPR-9119/pom.xml
+++ b/SPR-9119/pom.xml
@@ -50,7 +50,7 @@
 	<repositories>
 		<repository>
 			<id>springsource</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 		</repository>
 	</repositories>
 </project>

--- a/SPR-9155/pom.xml
+++ b/SPR-9155/pom.xml
@@ -27,7 +27,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-9181/pom.xml
+++ b/SPR-9181/pom.xml
@@ -38,7 +38,7 @@
 		<repository>
 			<id>springsource</id>
 			<name>SpringSource Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-9204/pom.xml
+++ b/SPR-9204/pom.xml
@@ -163,7 +163,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9215/pom.xml
+++ b/SPR-9215/pom.xml
@@ -78,7 +78,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 		</repository>
 	</repositories>
 	<build>

--- a/SPR-9239/pom.xml
+++ b/SPR-9239/pom.xml
@@ -162,7 +162,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9243/pom.xml
+++ b/SPR-9243/pom.xml
@@ -67,7 +67,7 @@
 		<repository>
 			<id>repo.springsource.org</id>
 			<name>SpringSource Repository</name>
-			<url>http://repo.springsource.org/libs-snapshot</url>
+			<url>https://repo.springsource.org/libs-snapshot</url>
 		</repository>
 	</repositories>
 	<build>

--- a/SPR-9244/pom.xml
+++ b/SPR-9244/pom.xml
@@ -168,7 +168,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9255/pom.xml
+++ b/SPR-9255/pom.xml
@@ -27,7 +27,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-9290/pom.xml
+++ b/SPR-9290/pom.xml
@@ -161,7 +161,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9329/pom.xml
+++ b/SPR-9329/pom.xml
@@ -177,7 +177,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9374/pom.xml
+++ b/SPR-9374/pom.xml
@@ -168,7 +168,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9464/pom.xml
+++ b/SPR-9464/pom.xml
@@ -50,7 +50,7 @@
     <repositories>
         <repository>
             <id>spring.milestone</id>
-            <url>http://repo.springsource.org/libs-milestone</url>
+            <url>https://repo.springsource.org/libs-milestone</url>
         </repository>
     </repositories>
     <dependencies>

--- a/SPR-9498/pom.xml
+++ b/SPR-9498/pom.xml
@@ -175,7 +175,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9566/pom.xml
+++ b/SPR-9566/pom.xml
@@ -8,7 +8,7 @@
 	<version>1.0.0.CI-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>Spring Utility</name>
-	<url>http://www.springframework.org</url>
+	<url>https://www.springframework.org</url>
 	<description>
 		<![CDATA[
       This project is a minimal jar utility with Spring configuration.

--- a/SPR-9575/pom.xml
+++ b/SPR-9575/pom.xml
@@ -189,7 +189,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9600/pom.xml
+++ b/SPR-9600/pom.xml
@@ -74,7 +74,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-9601/pom.xml
+++ b/SPR-9601/pom.xml
@@ -178,7 +178,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9610/pom.xml
+++ b/SPR-9610/pom.xml
@@ -163,7 +163,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9637/pom.xml
+++ b/SPR-9637/pom.xml
@@ -32,7 +32,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9638/pom.xml
+++ b/SPR-9638/pom.xml
@@ -27,7 +27,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-9646/pom.xml
+++ b/SPR-9646/pom.xml
@@ -161,7 +161,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9657/pom.xml
+++ b/SPR-9657/pom.xml
@@ -170,7 +170,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9667/pom.xml
+++ b/SPR-9667/pom.xml
@@ -7,7 +7,7 @@
 	<packaging>war</packaging>
 	<version>0.0.1</version>
 
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 	<name>test</name>
 	<description>
 		spring 3.1 to 3.2 migration - non regression test
@@ -227,7 +227,7 @@
 		<repository>
 			<id>MavenRepo1</id>
 			<name>Maven Repository</name>
-			<url>http://repo1.maven.org/maven2/</url>
+			<url>https://repo1.maven.org/maven2/</url>
 			<releases><enabled>true</enabled></releases>
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
@@ -236,7 +236,7 @@
         <repository>
             <id>org.springframework.maven.snapshot</id>
             <name>Spring Maven Snapshot Repository</name>
-            <url>http://maven.springframework.org/snapshot</url>
+            <url>https://maven.springframework.org/snapshot</url>
             <releases><enabled>false</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </repository>
@@ -245,7 +245,7 @@
         <repository>
             <id>org.springframework.maven.milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
             <snapshots><enabled>false</enabled></snapshots>
         </repository>
         

--- a/SPR-9670/pom.xml
+++ b/SPR-9670/pom.xml
@@ -27,7 +27,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-9702/pom.xml
+++ b/SPR-9702/pom.xml
@@ -22,7 +22,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/libs-snapshot</url>
+			<url>https://repo.springsource.org/libs-snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-9723/build.gradle
+++ b/SPR-9723/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'groovy'
 apply plugin: 'eclipse'
 
 repositories {
-    maven { url 'http://repo.grails.org/grails/core' }
+    maven { url 'https://repo.grails.org/grails/core' }
     mavenCentral()
 }
 

--- a/SPR-9756/pom.xml
+++ b/SPR-9756/pom.xml
@@ -6,7 +6,7 @@
     <packaging>war</packaging>
     <version>1.0.0-SNAPSHOT</version>
     <name>Repro project for SPR-9756</name>
-    <url>http://maven.apache.org</url>
+    <url>https://maven.apache.org</url>
 
     <properties>
         <java-version>1.6</java-version>
@@ -18,7 +18,7 @@
         <repository>
         <id>s2</id>
         <name>s2 snapshot</name>
-        <url>http://repo.springsource.org/libs-snapshot</url>
+        <url>https://repo.springsource.org/libs-snapshot</url>
         </repository>
     </repositories>
 

--- a/SPR-9795/pom.xml
+++ b/SPR-9795/pom.xml
@@ -32,20 +32,20 @@
 		<!--
 		<repository>
 			<id>s2-release</id>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 		</repository>
 		<repository>
 			<id>s2-milestone</id>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 		<repository>
 			<id>s2-staging</id>
-			<url>http://repo.springsource.org/libs-staging-local</url>
+			<url>https://repo.springsource.org/libs-staging-local</url>
 		</repository>
 		-->
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-9818/pom.xml
+++ b/SPR-9818/pom.xml
@@ -170,7 +170,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9832/pom.xml
+++ b/SPR-9832/pom.xml
@@ -169,7 +169,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9838/pom.xml
+++ b/SPR-9838/pom.xml
@@ -163,7 +163,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9849/pom.xml
+++ b/SPR-9849/pom.xml
@@ -175,7 +175,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9851/pom.xml
+++ b/SPR-9851/pom.xml
@@ -27,7 +27,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>

--- a/SPR-9895/pom.xml
+++ b/SPR-9895/pom.xml
@@ -163,7 +163,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9940/pom.xml
+++ b/SPR-9940/pom.xml
@@ -181,7 +181,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9943/pom.xml
+++ b/SPR-9943/pom.xml
@@ -13,7 +13,7 @@
     <repositories>
         <repository>
             <id>s2-release</id>
-            <url>http://repo.springsource.org/libs-snapshot</url>
+            <url>https://repo.springsource.org/libs-snapshot</url>
         </repository>
     </repositories>
 

--- a/SPR-9964/pom.xml
+++ b/SPR-9964/pom.xml
@@ -166,7 +166,7 @@
 		<repository>
 			<id>spring-maven-snapshot</id>
 			<name>Springframework Maven Snapshot Repository</name>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/SPR-9989/pom.xml
+++ b/SPR-9989/pom.xml
@@ -32,20 +32,20 @@
 		<!--
 		<repository>
 			<id>s2-release</id>
-			<url>http://repo.springsource.org/release</url>
+			<url>https://repo.springsource.org/release</url>
 		</repository>
 		<repository>
 			<id>s2-milestone</id>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 		<repository>
 			<id>s2-staging</id>
-			<url>http://repo.springsource.org/libs-staging-local</url>
+			<url>https://repo.springsource.org/libs-staging-local</url>
 		</repository>
 		-->
 		<repository>
 			<id>s2-snapshot</id>
-			<url>http://repo.springsource.org/snapshot</url>
+			<url>https://repo.springsource.org/snapshot</url>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
 	</repositories>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://hl7api.sourceforge.net/m2 (404) migrated to:  
  http://hl7api.sourceforge.net/m2 ([https](https://hl7api.sourceforge.net/m2) result AnnotatedConnectException).
* http://spring-roo-repository.springsource.org/release (404) migrated to:  
  http://spring-roo-repository.springsource.org/release ([https](https://spring-roo-repository.springsource.org/release) result SSLHandshakeException).
* http://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.52/bin/apache-tomcat-7.0.52.zip (404) migrated to:  
  http://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.52/bin/apache-tomcat-7.0.52.zip ([https](https://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.52/bin/apache-tomcat-7.0.52.zip) result SSLHandshakeException).
* http://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.56/bin/apache-tomcat-7.0.56.zip (404) migrated to:  
  http://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.56/bin/apache-tomcat-7.0.56.zip ([https](https://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.56/bin/apache-tomcat-7.0.56.zip) result SSLHandshakeException).
* http://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57.zip (404) migrated to:  
  http://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57.zip ([https](https://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.57/bin/apache-tomcat-7.0.57.zip) result SSLHandshakeException).
* http://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.59/bin/apache-tomcat-7.0.59.zip (404) migrated to:  
  http://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.59/bin/apache-tomcat-7.0.59.zip ([https](https://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.59/bin/apache-tomcat-7.0.59.zip) result SSLHandshakeException).
* http://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.64/bin/apache-tomcat-7.0.64.zip (404) migrated to:  
  http://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.64/bin/apache-tomcat-7.0.64.zip ([https](https://www.eu.apache.org/dist/tomcat/tomcat-7/v7.0.64/bin/apache-tomcat-7.0.64.zip) result SSLHandshakeException).
* http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.14/bin/apache-tomcat-8.0.14.zip (404) migrated to:  
  http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.14/bin/apache-tomcat-8.0.14.zip ([https](https://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.14/bin/apache-tomcat-8.0.14.zip) result SSLHandshakeException).
* http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.15/bin/apache-tomcat-8.0.15.zip (404) migrated to:  
  http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.15/bin/apache-tomcat-8.0.15.zip ([https](https://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.15/bin/apache-tomcat-8.0.15.zip) result SSLHandshakeException).
* http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.18/bin/apache-tomcat-8.0.18.zip (404) migrated to:  
  http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.18/bin/apache-tomcat-8.0.18.zip ([https](https://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.18/bin/apache-tomcat-8.0.18.zip) result SSLHandshakeException).
* http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.20/bin/apache-tomcat-8.0.20.zip (404) migrated to:  
  http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.20/bin/apache-tomcat-8.0.20.zip ([https](https://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.20/bin/apache-tomcat-8.0.20.zip) result SSLHandshakeException).
* http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.23/bin/apache-tomcat-8.0.23.zip (404) migrated to:  
  http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.23/bin/apache-tomcat-8.0.23.zip ([https](https://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.23/bin/apache-tomcat-8.0.23.zip) result SSLHandshakeException).
* http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip (404) migrated to:  
  http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip ([https](https://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip) result SSLHandshakeException).
* http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.3/bin/apache-tomcat-8.0.3.zip (404) migrated to:  
  http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.3/bin/apache-tomcat-8.0.3.zip ([https](https://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.3/bin/apache-tomcat-8.0.3.zip) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://repo.openehealth.org/maven2/releases (UnknownHostException) migrated to:  
  https://repo.openehealth.org/maven2/releases ([https](https://repo.openehealth.org/maven2/releases) result UnknownHostException).
* http://repo.openehealth.org/maven2/snapshots (UnknownHostException) migrated to:  
  https://repo.openehealth.org/maven2/snapshots ([https](https://repo.openehealth.org/maven2/snapshots) result UnknownHostException).
* http://repository.codehaus.org (UnknownHostException) migrated to:  
  https://repository.codehaus.org ([https](https://repository.codehaus.org) result UnknownHostException).
* http://archive.apache.org/dist/tomcat/tomcat-8/v (404) migrated to:  
  https://archive.apache.org/dist/tomcat/tomcat-8/v ([https](https://archive.apache.org/dist/tomcat/tomcat-8/v) result 404).
* http://docs.spring.io/spring-security/site/docs/current/apidocs/ (301) migrated to:  
  https://docs.spring.io/spring-security/site/docs/current/apidocs/ ([https](https://docs.spring.io/spring-security/site/docs/current/apidocs/) result 404).
* http://download.java.net/maven/2/ (301) migrated to:  
  https://download.java.net/maven/2/ ([https](https://download.java.net/maven/2/) result 404).
* http://gwtrepo.googlecode.com/svn/repo (404) migrated to:  
  https://gwtrepo.googlecode.com/svn/repo ([https](https://gwtrepo.googlecode.com/svn/repo) result 404).
* http://m2.neo4j.org/releases (404) migrated to:  
  https://m2.neo4j.org/releases ([https](https://m2.neo4j.org/releases) result 404).
* http://s3.amazonaws.com/maven.springframework.org/milestone (404) migrated to:  
  https://s3.amazonaws.com/maven.springframework.org/milestone ([https](https://s3.amazonaws.com/maven.springframework.org/milestone) result 404).
* http://test4spring4.googlecode.com/svn/trunk/ (404) migrated to:  
  https://test4spring4.googlecode.com/svn/trunk/ ([https](https://test4spring4.googlecode.com/svn/trunk/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.35/bin/apache-tomcat-6.0.35.zip migrated to:  
  https://archive.apache.org/dist/tomcat/tomcat-6/v6.0.35/bin/apache-tomcat-6.0.35.zip ([https](https://archive.apache.org/dist/tomcat/tomcat-6/v6.0.35/bin/apache-tomcat-6.0.35.zip) result 200).
* http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.44/bin/apache-tomcat-6.0.44.zip migrated to:  
  https://archive.apache.org/dist/tomcat/tomcat-6/v6.0.44/bin/apache-tomcat-6.0.44.zip ([https](https://archive.apache.org/dist/tomcat/tomcat-6/v6.0.44/bin/apache-tomcat-6.0.44.zip) result 200).
* http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.64/bin/apache-tomcat-7.0.64.zip migrated to:  
  https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.64/bin/apache-tomcat-7.0.64.zip ([https](https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.64/bin/apache-tomcat-7.0.64.zip) result 200).
* http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.67/bin/apache-tomcat-7.0.67.zip migrated to:  
  https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.67/bin/apache-tomcat-7.0.67.zip ([https](https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.67/bin/apache-tomcat-7.0.67.zip) result 200).
* http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.15/bin/apache-tomcat-8.0.15.zip migrated to:  
  https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.15/bin/apache-tomcat-8.0.15.zip ([https](https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.15/bin/apache-tomcat-8.0.15.zip) result 200).
* http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip migrated to:  
  https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip ([https](https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26.zip) result 200).
* http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.32/bin/apache-tomcat-8.0.32.zip migrated to:  
  https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.32/bin/apache-tomcat-8.0.32.zip ([https](https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.32/bin/apache-tomcat-8.0.32.zip) result 200).
* http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip migrated to:  
  https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip ([https](https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip) result 200).
* http://docs.jboss.org/hibernate/stable/core/javadocs/ migrated to:  
  https://docs.jboss.org/hibernate/stable/core/javadocs/ ([https](https://docs.jboss.org/hibernate/stable/core/javadocs/) result 200).
* http://docs.spring.io/spring-mobile/docs/current/api/ migrated to:  
  https://docs.spring.io/spring-mobile/docs/current/api/ ([https](https://docs.spring.io/spring-mobile/docs/current/api/) result 200).
* http://docs.spring.io/spring/docs/current/javadoc-api/ migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/ ([https](https://docs.spring.io/spring/docs/current/javadoc-api/) result 200).
* http://lh3.googleusercontent.com/-riyCbTcpYdo/AAAAAAAAAAI/AAAAAAAAAAA/47MhS2LUlZo/s48-c-k/photo.jpg migrated to:  
  https://lh3.googleusercontent.com/-riyCbTcpYdo/AAAAAAAAAAI/AAAAAAAAAAA/47MhS2LUlZo/s48-c-k/photo.jpg ([https](https://lh3.googleusercontent.com/-riyCbTcpYdo/AAAAAAAAAAI/AAAAAAAAAAA/47MhS2LUlZo/s48-c-k/photo.jpg) result 200).
* http://logging.apache.org/log4j/2.x/log4j-api/apidocs/ migrated to:  
  https://logging.apache.org/log4j/2.x/log4j-api/apidocs/ ([https](https://logging.apache.org/log4j/2.x/log4j-api/apidocs/) result 200).
* http://logging.apache.org/log4j/2.x/log4j-core/apidocs/ migrated to:  
  https://logging.apache.org/log4j/2.x/log4j-core/apidocs/ ([https](https://logging.apache.org/log4j/2.x/log4j-core/apidocs/) result 200).
* http://maven.apache.org migrated to:  
  https://maven.apache.org ([https](https://maven.apache.org) result 200).
* http://repo.spring.io/libs-milestone/ migrated to:  
  https://repo.spring.io/libs-milestone/ ([https](https://repo.spring.io/libs-milestone/) result 200).
* http://repo.spring.io/libs-snapshot/ migrated to:  
  https://repo.spring.io/libs-snapshot/ ([https](https://repo.spring.io/libs-snapshot/) result 200).
* http://repo1.maven.org/maven2/ migrated to:  
  https://repo1.maven.org/maven2/ ([https](https://repo1.maven.org/maven2/) result 200).
* http://repository.primefaces.org migrated to:  
  https://repository.primefaces.org ([https](https://repository.primefaces.org) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://code.google.com/p/javawiki/wiki/StarupMaven?wl=zh-Hant migrated to:  
  https://code.google.com/p/javawiki/wiki/StarupMaven?wl=zh-Hant ([https](https://code.google.com/p/javawiki/wiki/StarupMaven?wl=zh-Hant) result 301).
* http://code.google.com/p/test4spring4/source/browse/trunk/ migrated to:  
  https://code.google.com/p/test4spring4/source/browse/trunk/ ([https](https://code.google.com/p/test4spring4/source/browse/trunk/) result 301).
* http://m2.neo4j.org/snapshots migrated to:  
  https://m2.neo4j.org/snapshots ([https](https://m2.neo4j.org/snapshots) result 301).
* http://repo.springsource.org/libs-milestone migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/libs-snapshot migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* http://repo.springsource.org/libs-staging-local migrated to:  
  https://repo.springsource.org/libs-staging-local ([https](https://repo.springsource.org/libs-staging-local) result 301).
* http://repo.springsource.org/milestone migrated to:  
  https://repo.springsource.org/milestone ([https](https://repo.springsource.org/milestone) result 301).
* http://repo.springsource.org/release migrated to:  
  https://repo.springsource.org/release ([https](https://repo.springsource.org/release) result 301).
* http://repo.springsource.org/snapshot migrated to:  
  https://repo.springsource.org/snapshot ([https](https://repo.springsource.org/snapshot) result 301).
* http://www.springframework.org migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* http://download.oracle.com/javaee/7/api/ migrated to:  
  https://download.oracle.com/javaee/7/api/ ([https](https://download.oracle.com/javaee/7/api/) result 302).
* http://download.oracle.com/javase/7/docs/api/ migrated to:  
  https://download.oracle.com/javase/7/docs/api/ ([https](https://download.oracle.com/javase/7/docs/api/) result 302).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://maven.springframework.org/snapshot migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).
* http://repo.grails.org/grails/core migrated to:  
  https://repo.grails.org/grails/core ([https](https://repo.grails.org/grails/core) result 302).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-snapshot migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/milestone migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* http://repo.spring.io/snapshot migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).
* http://repo1.maven.org/maven2 migrated to:  
  https://repo1.maven.org/maven2 ([https](https://repo1.maven.org/maven2) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:4444/selenium-server/driver/?cmd=shutDownSeleniumServer
* http://localhost:8080/test4spring4
* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance